### PR TITLE
fix: Add isDpsWired property to AccessHub

### DIFF
--- a/src/access-hub.ts
+++ b/src/access-hub.ts
@@ -2144,5 +2144,16 @@ export class AccessHub extends AccessDevice {
         }
       });
     }
+
+    // Define isDpsWired separately since the main loop skips "Dps" (only hkDpsState has a manual implementation that needs to be excluded from the loop).
+    Object.defineProperty(AccessHub.prototype, "isDpsWired", {
+
+      configurable: true,
+      enumerable: true,
+      get(this: AccessHub) {
+
+        return this.isWired("Dps");
+      }
+    });
   }
 }


### PR DESCRIPTION
# Problem
On devices with DPS wiring, the HomeKit `ContactSensor` would always report closed and never update. Any feature depending on DPS state would behave incorrectly as a result.

The root cause: `isDpsWired` was never defined on the prototype, so every call returned `undefined` (falsy), causing `hubDpsState` to always treat the DPS as unwired.

This happened because the static initializer loop filters out `"Dps"` to skip auto-generating `hkDpsState` (which has a manual implementation). But the same loop also defines `is${Input}Wired`, so `isDpsWired` was silently dropped as a side effect.

# Fix
Define `isDpsWired` explicitly outside the loop. The loop comment has been updated to clarify that only `hkDpsState` needs to be excluded, not the entire Dps input.

----------
PR description written with assistance from Claude (Anthropic).